### PR TITLE
Use the native input definition to register options.

### DIFF
--- a/src/AnnotatedCommand.php
+++ b/src/AnnotatedCommand.php
@@ -207,7 +207,7 @@ class AnnotatedCommand extends Command implements HelpDocumentAlter
                 $description = $automaticOptions[$name]->getDescription();
                 $inputOption = static::inputOptionSetDescription($inputOption, $description);
             }
-            $this->getDefinition()->addOption($inputOption);
+            $this->getNativeDefinition()->addOption($inputOption);
         }
     }
 


### PR DESCRIPTION
### Disposition
This pull request:

- [x] Fixes a test
